### PR TITLE
Move the package `pyuom` to top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,4 @@ setup(name="pyuom",
       description="A Units of Measure Library",
       author='K. Hanson',
       url='https://github.com/katerina7479/python-units-of-measure.git',
-      package_dir={'':'pyuom'},
-      py_modules=['PhysicalQuantity', 'UnitOfMeasure', 'Acceleration', 'Angle',
-                  'Area', 'Length', 'ElectricCurrent', 'LuminousIntensity',
-                  'Mass', 'Pressure', 'Temperature', 'Time', 'Velocity', 'Volume'])
+      packages=['pyuom'],)


### PR DESCRIPTION
This allows to install the package via GIT and then import module on demand as needed. 

e.g. `from pyuom.Length import Length` instead of `import Length` which is the case if you directly install.